### PR TITLE
Move Nitrogen after other elements starting with "N"

### DIFF
--- a/src/constants.typ
+++ b/src/constants.typ
@@ -1,4 +1,4 @@
-#let elements = ("Ac","Ag","Al","Am","Ar","As","At","Au","Ba","Be","Bh","Bi","Bk","Br","B","Ca","Cd","Ce","Cf","Cl","Cm","Co","Cr","Cs","Cu","C","Ds","Db","Dy","Er","Es","Eu","Fe","Fm","Fr","F","Ga","Gd","Ge","He","Hf","Hg","Ho","Hs","H","In","Ir","I","Kr","K","La","Li","Lr","Lu","Md","Mg","Mn","Mo","Mt","N","Na","Nb","Nd","Ne","Ni","No","Np","Os","O","Pa","Pb","Pd","Pm","Po","Pr","Pt","Pu","P","Ra","Rb","Re","Rf","Rg","Rh","Rn","Ru","Sb","Sc","Se","Sg","Si","Sm","Sn","Sr","S","Ta","Tb","Tc","Te","Th\b","Ti","Tl","Tm","U","V","W","Xe","Yb","Y","Zn","Zr")
+#let elements = ("Ac","Ag","Al","Am","Ar","As","At","Au","Ba","Be","Bh","Bi","Bk","Br","B","Ca","Cd","Ce","Cf","Cl","Cm","Co","Cr","Cs","Cu","C","Ds","Db","Dy","Er","Es","Eu","Fe","Fm","Fr","F","Ga","Gd","Ge","He","Hf","Hg","Ho","Hs","H","In","Ir","I","Kr","K","La","Li","Lr","Lu","Md","Mg","Mn","Mo","Mt","Na","Nb","Nd","Ne","Ni","No","Np","N","Os","O","Pa","Pb","Pd","Pm","Po","Pr","Pt","Pu","P","Ra","Rb","Re","Rf","Rg","Rh","Rn","Ru","Sb","Sc","Se","Sg","Si","Sm","Sn","Sr","S","Ta","Tb","Tc","Te","Th\b","Ti","Tl","Tm","U","V","W","Xe","Yb","Y","Zn","Zr")
 
 #let pseudo-elements = (
     "D", 


### PR DESCRIPTION
 Move Nitrogen after other elements starting with "N" to avoid regex conflicts. This makes it consistent with other single-letter elements that also appear last.

I also noticed `"Th\b"` which is different from the rest. Is there a reason for that? If not, I could change that too in this or a separate PR.