### PR TITLE
Use context in stateful.typ

### DIFF
--- a/src/stateful.typ
+++ b/src/stateful.typ
@@ -2,9 +2,11 @@
 
 #let chem-toggle(bool) = {Chemistry-Style-disable-state.update(bool)}
 
-#let if-state-enabled( it , fn ) = {
-  if ( Chemistry-Style-disable-state.get() == false ){ return it }
-  return fn
+#let if-state-enabled(it, fn) = context {
+  if (not Chemistry-Style-disable-state.get()) {
+    return it
+  }
+  return fn 
 }
 
 #let chem-disabled(content) = {


### PR DESCRIPTION
When compiling with the latest version of Typst, a warning is given that `state.display` is deprecated. The use of context in `stateful.typ` fixes this warning.